### PR TITLE
Use jcenter(), not mavenCentral() for Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ version = '0.1-SNAPSHOT'
 description = 'JNA binding and Java wrapper for libbitcoinconsensus'
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
`jcenter()` is faster than `mavenCentral()` and will use `https://`

(I'm not sure what the corresponding change to `pom.xml` would be.)
