### PR TITLE
Add jcenter/bintray as repository for Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,26 @@
     <name>java-libbitcoinconsensus</name>
     <description>JNA binding and Java wrapper for libbitcoinconsensus</description>
     <url>https://github.com/dexX7/java-libbitcoinconsensus</url>
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray</name>
+            <url>https://jcenter.bintray.com</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>bintray-plugins</name>
+            <url>https://jcenter.bintray.com</url>
+        </pluginRepository>
+    </pluginRepositories>
     <dependencies>
         <dependency>
             <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
This pull request adds [jCenter](https://bintray.com/bintray/jcenter) from bintray.com as repository for Maven, to mirror the change via #2.

The [build logs](https://travis-ci.org/dexX7/java-libbitcoinconsensus/jobs/80797781) show that the new settings are applied.
