### PR TITLE
Start work on Spock tests 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'groovy'
 
 group = 'co.bitwatch.libbitcoinconsensus'
 version = '0.1-SNAPSHOT'
@@ -12,4 +13,9 @@ repositories {
 dependencies {
     compile group: 'net.java.dev.jna', name: 'jna', version: '4.2.0'
     testCompile group: 'junit', name: 'junit', version:'4.12'
+
+    testCompile "org.codehaus.groovy:groovy:2.4.4"
+    testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
+        exclude module: 'groovy-all'
+    }
 }

--- a/src/test/groovy/co/bitwatch/libbitcoinconsensus/BitcoinConsensusSpec.groovy
+++ b/src/test/groovy/co/bitwatch/libbitcoinconsensus/BitcoinConsensusSpec.groovy
@@ -1,0 +1,39 @@
+import co.bitwatch.libbitcoinconsensus.BitcoinConsensus
+import spock.lang.Specification
+
+import static co.bitwatch.libbitcoinconsensus.util.StringUtil.hexToBinary
+
+class BitcoinConsensusSpec extends Specification {
+    private static BitcoinConsensus lib;
+
+    def "test"() {
+        expect:
+        1 == 1
+    }
+
+    def testBitcoinConsensusVerifyScript_OK() {
+        when:
+        def txTo = hexToBinary("01000000015884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4000000006a4730440220340f35055aceb14250e4954b23743332f671eb803263f363d1d7272f1d487209022037a0eaf7cb73897ba9069fc538e7275c5ae188e934ae47ca4a70453b64fc836401210234257444bd3aead2b851bda4288d60abe34095a2a8d49aff1d4d19773d22b32cffffffff01a0860100000000001976a9147821c0a3768aa9d1a37e16cf76002aef5373f1a888ac00000000")
+        def scriptPubKey = hexToBinary("76a9144621d47f08fcb1e6be0b91144202de7a186deade88ac")
+
+        def result = lib.VerifyScript(scriptPubKey, txTo, 0);
+
+        then:
+        result
+    }
+
+    def testBitcoinConsensusVerifyScript_InvalidScript() {
+        when:
+        def txTo = hexToBinary("01000000015884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4000000006a4730440220340f35055aceb14250e4954b23743332f671eb803263f363d1d7272f1d487209022037a0eaf7cb73897ba9069fc538e7275c5ae188e934ae47ca4a70453b64fc836401210234257444bd3aead2b851bda4288d60abe34095a2a8d49aff1d4d19773d22b32cffffffff01a0860100000000001976a9147821c0a3768aa9d1a37e16cf76002aef5373f1a888ac00000000");
+        def scriptPubKey = hexToBinary("76a9147821c0a3768aa9d1a37e16cf76002aef5373f1a888ac");
+
+        def result = lib.VerifyScript(scriptPubKey, txTo, 0);
+
+        then:
+        !result
+    }
+
+    def setupSpec() {
+        lib = new BitcoinConsensus();
+    }
+}


### PR DESCRIPTION
- Add Groovy and Spock to build.gradle
- Reimplement a few tests in Groovy/Spock as P.O.C.

The `build.gradle` changes are ready to go, but I don't see the current Spock tests as adding any value to the JUnit tests that already exist.
